### PR TITLE
impl `std::error::Error` for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,8 @@ pub enum Error {
     WifKey,
 }
 
+impl std::error::Error for Error {}
+
 /// Internal Functions to manipulate an arbitrary number of bytes [u8].
 trait BytesManipulation {
     /// Encode informed data in base 58 check.


### PR DESCRIPTION
Hello. Implementing `std::error::Error` for custom error types is idiomatic in Rust, as this PR does.