### PR TITLE
Add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ unicode-normalization = { version = "0.1.19", default-features = false }
 
 [features]
 default = ["std"]
-std = ["rand/std", "sha2/std", "unicode-normalization/std", "digest/std"]
+std = ["rand/std", "rand/std_rng", "sha2/std", "unicode-normalization/std", "digest/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,15 @@ readme = "README.md"
 
 [dependencies]
 aes = "0.7.4"
-bs58 = "0.4.0"
-rand = "0.8.4"
-ripemd160 = "0.9.1"
+bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
+rand = { version = "0.8.4", default-features = false, features = ["alloc"] }
+ripemd160 = { version = "0.9.0", default-features = false }
 scrypt = { version = "0.7.0", default-features = false }
-secp256k1 = "0.20.3"
-sha2 = "0.9.5"
-unicode-normalization = "0.1.19"
+secp256k1 = { version = "0.20.0", default-features = false, features = ["alloc"] }
+digest = { version = "0.10.7", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
+unicode-normalization = { version = "0.1.19", default-features = false }
+
+[features]
+default = ["std"]
+std = ["rand/std", "sha2/std", "unicode-normalization/std", "digest/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,7 +821,7 @@ impl Generate for str {
 
         let mut pass_point_mul = PublicKey::from_slice(&pass_point).map_err(|_| Error::PubKey)?;
 
-        fill_random_bytes(&mut owner_salt);
+        fill_random_bytes(&mut seed_b);
 
         let factor_b = seed_b.hash256();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,10 +181,15 @@ use alloc::{
     vec
 };
 
-fn f() {
-    let s = String::new();
-    Secp256k1::<secp256k1::All>::new();
-}
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+use std::{
+    string::String,
+    vec,
+    vec::Vec,
+};
 
 use aes::Aes256;
 use aes::cipher::{
@@ -804,7 +809,7 @@ impl Generate for str {
         let mut pass_factor = [0x00; 32];
         let mut seed_b = [0x00; 24];
 
-        // rand::thread_rng().fill_bytes(&mut owner_salt);
+        fill_random_bytes(&mut owner_salt);
 
         scrypt::scrypt(
             self.nfc().collect::<String>().as_bytes(),
@@ -817,8 +822,7 @@ impl Generate for str {
 
         let mut pass_point_mul = PublicKey::from_slice(&pass_point).map_err(|_| Error::PubKey)?;
 
-        // TODO: RNG
-        // rand::thread_rng().fill_bytes(&mut seed_b);
+        fill_random_bytes(&mut owner_salt);
 
         let factor_b = seed_b.hash256();
 
@@ -882,6 +886,12 @@ impl Generate for str {
 
         Ok(result_bytes.encode_base58ck())
     }
+}
+
+fn fill_random_bytes(buf: &mut [u8]) {
+    #[cfg(feature = "std")]
+    rand::thread_rng().fill_bytes(buf)
+    // TODO: no_std
 }
 
 impl PrivateKeyManipulation for [u8; 32] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,8 @@ pub enum Error {
     WifKey,
 }
 
+impl std::error::Error for Error {}
+
 /// Internal Functions to manipulate an arbitrary number of bytes [u8].
 trait BytesManipulation {
     /// Encode informed data in base 58 check.


### PR DESCRIPTION
This PR adds `no_std` support and allow to run under `no_std` + `alloc` environment.

However there's one blocker: the RNG thing:

https://github.com/bczhc/bip38/blob/7265fa7b50b6b76faef2c206cf2205f0a9668c5c/src/lib.rs#L890-L899

In `generate` method, `thread_rng`s are used. But under `no_std`, there's no such RNG. Here should have some discussions. One solution is to pass an `RngCore` to `generate`, and allow the caller to choose the RNG.

I don't know if there's any method to generate **nondeterministic** random numbers under simple embedded systems. First we should grab a seed, and if the initial seed is deterministic, the further random numbers are all deterministic. It's impossible achieve an nondeterministic seed only from the software.

For example, here's an RNG implementation for Raspberry Pi Pico:
```rust
use rand::{Error, RngCore};
use rp_pico::pac::ROSC;

pub struct RoscRng;

impl RoscRng {
    #[inline]
    fn random_byte() -> u8 {
        let mut b = 0_u8;
        for i in 0..8 {
            let bits = unsafe { (*ROSC::PTR).randombit.read().bits() } as u8;
            b |= (bits & 0b1) << i;
        }
        b
    }
}

impl RngCore for RoscRng {
    fn next_u32(&mut self) -> u32 {
        let mut u = [0_u8; 4];
        self.fill_bytes(&mut u);
        u32::from_le_bytes(u)
    }

    fn next_u64(&mut self) -> u64 {
        let mut u = [0_u8; 8];
        self.fill_bytes(&mut u);
        u64::from_le_bytes(u)
    }

    fn fill_bytes(&mut self, dest: &mut [u8]) {
        for x in dest.iter_mut() {
            *x = Self::random_byte();
        }
    }

    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
        self.fill_bytes(dest);
        Ok(())
    }
}
```